### PR TITLE
Scaffold Vite React Tailwind base setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OP Item DB</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+
+function App() {
+  const [searchTerm, setSearchTerm] = useState("");
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 bg-black/30 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-16 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-emerald-400/80">
+            Minecraft Item Datenbank
+          </p>
+          <h1 className="text-4xl font-bold sm:text-5xl">Hello OP-Item-DB</h1>
+          <p className="mx-auto max-w-2xl text-base text-slate-300">
+            Dies ist das künftige Zuhause für eine kuratierte Sammlung von Minecraft-Items,
+            kombiniert mit Supabase, Cloudflare Pages und Discord-Login.
+          </p>
+          <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Items durchsuchen…"
+              className="w-full max-w-sm rounded-lg border border-slate-700 bg-slate-900/60 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
+            />
+            <button className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-5 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60">
+              Suche starten
+            </button>
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto flex max-w-5xl flex-1 flex-col gap-12 px-6 py-16">
+        <section className="grid gap-6 sm:grid-cols-2">
+          {[...Array(4)].map((_, index) => (
+            <article
+              key={index}
+              className="flex flex-col gap-4 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="h-14 w-14 rounded-xl bg-emerald-500/20" />
+                  <div>
+                    <h2 className="text-lg font-semibold">Platzhalter Item #{index + 1}</h2>
+                    <p className="text-sm text-slate-400">Kurze Beschreibung folgt…</p>
+                  </div>
+                </div>
+                <span className="rounded-full border border-emerald-500/40 px-3 py-1 text-xs font-medium text-emerald-300">
+                  Kategorie
+                </span>
+              </div>
+              <p className="text-sm leading-relaxed text-slate-300">
+                Dieser Bereich ist ein Platzhalter für Metadaten, Crafting-Rezepte und weitere Informationen,
+                die später aus der Datenbank geladen werden.
+              </p>
+              <div className="flex flex-wrap gap-2 text-xs">
+                {["Selten", "Verzauberbar", "Stackbar"].map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full border border-slate-700 bg-slate-900/80 px-3 py-1 text-emerald-200"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </section>
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/50 p-8 text-sm text-slate-300">
+          <h2 className="text-xl font-semibold text-slate-100">Roadmap</h2>
+          <p className="mt-3 text-slate-400">
+            Hier folgt später eine Roadmap mit Informationen zu anstehenden Features und Datenquellen.
+          </p>
+        </section>
+      </main>
+      <footer className="border-t border-slate-800 bg-black/40 py-8 text-center text-xs text-slate-500">
+        © {new Date().getFullYear()} OP Item DB. Erstellt mit Vite, React, Tailwind und Supabase.
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./index.html", "./src/**/*.{ts,tsx,jsx,js}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["Inter", "system-ui", "sans-serif"],
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "tailwind.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vite-ready HTML entry point and React bootstrap files
- configure Tailwind CSS, PostCSS, TypeScript, and Vite defaults
- scaffold a placeholder OP Item DB layout for the App component

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e54c3ff9a88324be538e76f9c87992