### PR TITLE
Add Supabase auth snippets and project checklist

### DIFF
--- a/docs/project-checklist.md
+++ b/docs/project-checklist.md
@@ -1,12 +1,12 @@
-# OP Item DB – Projekt-Checkliste
+# OP-Item-DB Projekt-Checkliste
 
-1. Repository vorbereiten (GitHub anlegen, Branch-Schutzregeln definieren, PR-Vorlagen erstellen).
-2. Lokale Entwicklungsumgebung einrichten (Node.js, pnpm, Supabase CLI, `.env`-Beispiele pflegen).
-3. Supabase-Projekt erstellen und mit lokalen/staging Umgebungen verknüpfen.
-4. Datenbankschema migrieren und Basisdaten für Item-Taxonomien einspielen.
-5. Row Level Security aktivieren und Policies für Ownership/Leserechte planen.
-6. Supabase Storage Buckets für Item-Bilder konfigurieren (Regeln, CDN, Upload-Workflows).
-7. Discord-OAuth in Supabase Auth registrieren (Redirect-URIs, Secrets, lokale Tests).
-8. Cloudflare Pages Functions API scaffolden (Supabase Client, Auth-Middleware, Routing).
-9. Vite + React + TypeScript + Tailwind Grundgerüst aufsetzen (Routing, Layout, UI-Komponenten).
-10. Deployment-Pipeline für Cloudflare Pages & Supabase konfigurieren (CI/CD, Secrets, Review-Apps).
+1. **Repository anlegen** – Neues Git-Repo `op-item-db` erstellen, README mit Projektvision und Tech-Stack anlegen, Branch-Schutz einrichten.
+2. **Lokale Dev-Umgebung** – Node.js (>=18), pnpm, Supabase CLI, Cloudflare Wrangler installieren; `.nvmrc`/`.tool-versions` pflegen; README mit Setup-Anleitung erweitern.
+3. **Supabase-Projekt** – Supabase Dashboard: neues Projekt, Datenbank-Region wählen, API-Keys sicher ablegen (1Password, env vars vorbereiten).
+4. **Datenbank-Schema** – SQL-Migration für Item-Tabellen (Items, Kategorien, Tags, Quellen), Relationen & Indizes definieren, Seeds für Kern-Daten.
+5. **Row Level Security (RLS)** – RLS global aktivieren, Policies für öffentliche Lesezugriffe und restriktive Schreibrechte (nur Admin-Rollen) erstellen.
+6. **Storage** – Bucket für Item-Assets (Icons, Screenshots) anlegen, öffentliche Lese-Richtlinien + Upload-Service-Rolle Policies definieren.
+7. **Discord-Auth** – Discord OAuth-Anwendung einrichten, Redirect-URIs (lokal + Produktion) setzen, Secrets in Supabase Auth Provider hinterlegen.
+8. **Pages Functions API** – Cloudflare Pages Functions Repo-Struktur anlegen, Supabase Service Role mit env binding konfigurieren, erste Health-Check-Route.
+9. **React-App Grundgerüst** – Vite + React + TS + Tailwind Setup, Layout, Routing, Supabase Client Provider, Basic Auth-Gate vorbereiten.
+10. **Deployment** – Cloudflare Pages Projekt verbinden, Build-Pipeline (pnpm build) definieren, Supabase API Keys & Wrangler Secrets setzen, Preview + Production Deploy testen.

--- a/docs/supabase-auth-snippets.md
+++ b/docs/supabase-auth-snippets.md
@@ -1,0 +1,30 @@
+# Supabase Auth Snippets (TypeScript)
+
+> **Hinweis:** Minimale Beispiel-Snippets als Referenz. Die finale Implementierung folgt in der App-Struktur.
+
+```ts
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!
+);
+```
+
+```ts
+export async function loginWithDiscord() {
+  await supabase.auth.signInWithOAuth({ provider: 'discord' });
+}
+```
+
+```ts
+export async function logout() {
+  await supabase.auth.signOut();
+}
+```
+
+```ts
+supabase.auth.onAuthStateChange((event, session) => {
+  console.log('Auth state changed:', event, session);
+});
+```


### PR DESCRIPTION
## Summary
- add minimal Supabase auth reference snippets for the upcoming app implementation
- refresh the OP-Item-DB project checklist with actionable next steps across the stack

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e5678527308324bc9bb361a43301df