### PR TITLE
Add Supabase-backed API routes and project checklist

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,40 @@
+# OP-Item-DB – Initial Setup Checklist
+
+1. **Repository anlegen**
+   - Neues GitHub-Repository `op-item-db` erstellen.
+   - Branch-Schutzregeln (PR-Review, Status-Checks) konfigurieren.
+   - Grundlegende Issue- und PR-Vorlagen hinzufügen.
+2. **Lokale Entwicklungsumgebung vorbereiten**
+   - Node.js (LTS), pnpm sowie Supabase CLI installieren.
+   - Repository klonen, `pnpm install` ausführen und Husky/Pre-commit-Hooks aktivieren.
+   - `.env.local` und `.env` mit Platzhaltern für Supabase, Cloudflare, Discord anlegen.
+3. **Supabase-Projekt aufsetzen**
+   - Neues Supabase-Projekt erstellen und Service-Role/Anon-Keys notieren.
+   - Supabase CLI mit Projekt verknüpfen (`supabase link`).
+   - Lokale Entwicklungsdatenbank mit `supabase start` verfügbar machen.
+4. **Datenbankschema migrieren**
+   - Migrationen (`supabase/migrations`) anwenden (`supabase db push` / `supabase db reset`).
+   - Seeds oder Default-Datensätze für Item-Typen, Rarities, Materials einspielen.
+5. **Row Level Security (RLS) validieren**
+   - Prüfen, dass Policies für Items & Taxonomien greifen.
+   - Tests für Insert/Update/Delete mit Auth- und Service-Role-Tokens durchführen.
+6. **Storage konfigurieren**
+   - Supabase Storage-Bucket `item-images` anlegen.
+   - Richtlinien für Upload/Read-Zugriff (nur Owner + Public-Lesen über signierte URLs) definieren.
+   - CDN/Resizing-Optionen evaluieren.
+7. **Discord-Auth integrieren**
+   - Discord OAuth-Applikation erstellen; Redirect-URI auf Supabase Auth einstellen.
+   - Provider in Supabase aktivieren und Scopes (`identify`, `email`) setzen.
+   - Test-Login über Supabase Auth testen und Metadaten (Username/Avatar) speichern.
+8. **Cloudflare Pages Functions API**
+   - `functions/api` für serverseitige Endpunkte deployen.
+   - Environment-Variablen (Supabase URL/Keys, Allowed Origin) hinterlegen.
+   - Staging- und Production-Branches konfigurieren.
+9. **React-App Grundgerüst**
+   - Vite + React + TypeScript + Tailwind Basis starten (`pnpm create vite`).
+   - Layout, Routing, Theming und Supabase Client (Auth + Storage) integrieren.
+   - UI-Komponenten für Login, Item-Listen, Filter und Detailseiten scaffolden.
+10. **Deployment automatisieren**
+    - Cloudflare Pages Projekt mit GitHub Repo verbinden.
+    - Build-Kommando (`pnpm run build`) und Output-Verzeichnis konfigurieren.
+    - Preview-Deployments aktivieren und Supabase/Site-URL in Discord-App aktualisieren.

--- a/functions/api/_shared.ts
+++ b/functions/api/_shared.ts
@@ -1,0 +1,118 @@
+import { createClient, type SupabaseClient, type User } from '@supabase/supabase-js';
+
+export interface Env {
+  SUPABASE_URL: string;
+  SUPABASE_SERVICE_ROLE: string;
+  ALLOWED_ORIGIN?: string;
+}
+
+const BASE_HEADERS: Record<string, string> = {
+  'Content-Type': 'application/json; charset=utf-8',
+  'Cache-Control': 'no-store',
+};
+
+export function initCors(
+  request: Request,
+  env: Env,
+): { headers: Headers } | { response: Response } {
+  const headers = new Headers(BASE_HEADERS);
+  headers.set('Vary', 'Origin');
+
+  const allowedOrigin = env.ALLOWED_ORIGIN;
+  const origin = request.headers.get('Origin');
+
+  if (allowedOrigin) {
+    if (origin && origin !== allowedOrigin) {
+      return {
+        response: new Response(
+          JSON.stringify({ error: 'Forbidden origin' }),
+          { status: 403, headers },
+        ),
+      };
+    }
+
+    if (origin) {
+      headers.set('Access-Control-Allow-Origin', origin);
+      headers.set('Access-Control-Allow-Credentials', 'true');
+    }
+  }
+
+  return { headers };
+}
+
+export function handleOptions(
+  request: Request,
+  env: Env,
+  allowedMethods: string[],
+): Response {
+  const cors = initCors(request, env);
+  if ('response' in cors) {
+    return cors.response;
+  }
+
+  const { headers } = cors;
+  headers.set('Access-Control-Allow-Methods', allowedMethods.join(', '));
+  headers.set('Access-Control-Allow-Headers', 'authorization,content-type');
+  headers.set('Access-Control-Max-Age', '86400');
+
+  return new Response(null, { status: 204, headers });
+}
+
+export function createServiceRoleClient(env: Env): SupabaseClient {
+  return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+    global: {
+      headers: {
+        'X-Client-Info': 'op-item-db-edge/1.0.0',
+      },
+    },
+  });
+}
+
+export async function requireAuthUser(
+  request: Request,
+  supabase: SupabaseClient,
+  headers: Headers,
+): Promise<{ user: User; token: string } | { response: Response }> {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    const unauthorizedHeaders = new Headers(headers);
+    unauthorizedHeaders.set('WWW-Authenticate', 'Bearer realm="Supabase"');
+    return {
+      response: new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: unauthorizedHeaders },
+      ),
+    };
+  }
+
+  const token = authHeader.slice(7).trim();
+  if (!token) {
+    const unauthorizedHeaders = new Headers(headers);
+    unauthorizedHeaders.set('WWW-Authenticate', 'Bearer realm="Supabase"');
+    return {
+      response: new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: unauthorizedHeaders },
+      ),
+    };
+  }
+
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data?.user) {
+    const unauthorizedHeaders = new Headers(headers);
+    unauthorizedHeaders.set('WWW-Authenticate', 'Bearer realm="Supabase"');
+    return {
+      response: new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: unauthorizedHeaders },
+      ),
+    };
+  }
+
+  return { user: data.user, token };
+}

--- a/functions/api/item-types.ts
+++ b/functions/api/item-types.ts
@@ -1,0 +1,30 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+import { createServiceRoleClient, handleOptions, initCors, type Env } from './_shared';
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request, env }) =>
+  handleOptions(request, env, ['GET']);
+
+export const onRequestGet: PagesFunction<Env> = async ({ env, request }) => {
+  const cors = initCors(request, env);
+  if ('response' in cors) {
+    return cors.response;
+  }
+
+  const { headers } = cors;
+  const supabase = createServiceRoleClient(env);
+
+  const { data, error } = await supabase
+    .from('item_types')
+    .select('id, slug, label, sort')
+    .order('sort', { ascending: true })
+    .order('id', { ascending: true });
+
+  if (error) {
+    return new Response(JSON.stringify({ error: 'Failed to fetch item types' }), {
+      status: 500,
+      headers,
+    });
+  }
+
+  return new Response(JSON.stringify({ data: data ?? [] }), { headers });
+};

--- a/functions/api/items.ts
+++ b/functions/api/items.ts
@@ -1,56 +1,350 @@
-import { createClient } from '@supabase/supabase-js';
 import type { PagesFunction } from '@cloudflare/workers-types';
+import { createServiceRoleClient, handleOptions, initCors, requireAuthUser, type Env } from './_shared';
 
-interface Env {
-  SUPABASE_URL: string;
-  SUPABASE_SERVICE_ROLE: string;
-  SUPABASE_ANON_KEY?: string;
-  ALLOWED_ORIGIN?: string;
-}
-
-const jsonHeaders = {
-  'Content-Type': 'application/json; charset=utf-8',
-  'Cache-Control': 'no-store',
+const SORT_MAP: Record<string, { column: string; ascending: boolean }> = {
+  newest: { column: 'created_at', ascending: false },
+  oldest: { column: 'created_at', ascending: true },
+  stars_desc: { column: 'stars', ascending: false },
+  stars_asc: { column: 'stars', ascending: true },
+  title_asc: { column: 'title', ascending: true },
+  title_desc: { column: 'title', ascending: false },
 };
 
+const MAX_PAGE_SIZE = 100;
+const DEFAULT_PAGE_SIZE = 20;
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request, env }) =>
+  handleOptions(request, env, ['GET', 'POST']);
+
 export const onRequestGet: PagesFunction<Env> = async ({ env, request }) => {
-  const origin = request.headers.get('Origin');
-  const allowedOrigin = env.ALLOWED_ORIGIN;
-  const headers = new Headers(jsonHeaders);
+  const cors = initCors(request, env);
+  if ('response' in cors) {
+    return cors.response;
+  }
 
-  if (allowedOrigin) {
-    headers.set('Vary', 'Origin');
+  const { headers } = cors;
+  const supabase = createServiceRoleClient(env);
 
-    if (origin && origin !== allowedOrigin) {
-      return new Response(
-        JSON.stringify({ error: 'Forbidden origin' }),
-        { status: 403, headers },
-      );
-    }
+  const url = new URL(request.url);
+  const params = url.searchParams;
 
-    if (origin) {
-      headers.set('Access-Control-Allow-Origin', origin);
+  const rawPage = params.get('page');
+  const rawPageSize = params.get('page_size');
+  const rawStarsMin = params.get('stars_min');
+  const rawStarsMax = params.get('stars_max');
+  const sortParam = params.get('sort') ?? 'newest';
+
+  const page = rawPage ? Number.parseInt(rawPage, 10) : 1;
+  const pageSize = rawPageSize ? Number.parseInt(rawPageSize, 10) : DEFAULT_PAGE_SIZE;
+  const starsMin = rawStarsMin ? Number.parseInt(rawStarsMin, 10) : undefined;
+  const starsMax = rawStarsMax ? Number.parseInt(rawStarsMax, 10) : undefined;
+
+  if (!Number.isInteger(page) || page < 1) {
+    return new Response(JSON.stringify({ error: 'Invalid page parameter' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
+    return new Response(JSON.stringify({ error: 'Invalid page_size parameter' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (starsMin !== undefined && (!Number.isInteger(starsMin) || starsMin < 0 || starsMin > 5)) {
+    return new Response(JSON.stringify({ error: 'Invalid stars_min parameter' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (starsMax !== undefined && (!Number.isInteger(starsMax) || starsMax < 0 || starsMax > 5)) {
+    return new Response(JSON.stringify({ error: 'Invalid stars_max parameter' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (starsMin !== undefined && starsMax !== undefined && starsMin > starsMax) {
+    return new Response(JSON.stringify({ error: 'stars_min cannot be greater than stars_max' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  const sortConfig = SORT_MAP[sortParam];
+  if (!sortConfig) {
+    return new Response(JSON.stringify({ error: 'Invalid sort parameter' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  let query = supabase
+    .from('items_public_v')
+    .select(
+      `
+        id,
+        title,
+        description,
+        item_type_id,
+        item_type_slug,
+        item_type_label,
+        rarity_id,
+        rarity_slug,
+        rarity_label,
+        rarity_color_hex,
+        material_id,
+        material_slug,
+        material_label,
+        stars,
+        created_at,
+        updated_at,
+        owner_user_id,
+        image_url
+      `,
+      { count: 'exact' },
+    );
+
+  const q = params.get('q');
+  if (q) {
+    const sanitized = q.replace(/[\\%_,]/g, ' ').trim();
+    if (sanitized) {
+      const pattern = `%${sanitized.replace(/\s+/g, ' ')}%`;
+      query = query.or(`title.ilike.${pattern},description.ilike.${pattern}`);
     }
   }
 
-  const client = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE, {
-    auth: { persistSession: false, detectSessionInUrl: false },
-    global: { headers: { 'X-Client-Info': 'op-item-db-edge/1.0.0' } },
-  });
+  const typeSlug = params.get('type');
+  if (typeSlug) {
+    query = query.eq('item_type_slug', typeSlug);
+  }
 
-  const { data, error } = await client
-    .from('items')
-    .select('id, name, category')
-    .order('name')
-    .limit(50);
+  const raritySlug = params.get('rarity');
+  if (raritySlug) {
+    query = query.eq('rarity_slug', raritySlug);
+  }
+
+  const materialSlug = params.get('material');
+  if (materialSlug) {
+    query = query.eq('material_slug', materialSlug);
+  }
+
+  if (starsMin !== undefined) {
+    query = query.gte('stars', starsMin);
+  }
+
+  if (starsMax !== undefined) {
+    query = query.lte('stars', starsMax);
+  }
+
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+
+  query = query.order(sortConfig.column, { ascending: sortConfig.ascending }).range(from, to);
+
+  const { data, error, count } = await query;
 
   if (error) {
-    console.error('Supabase query failed', error);
-    return new Response(
-      JSON.stringify({ error: 'Failed to fetch items' }),
-      { status: 500, headers },
-    );
+    return new Response(JSON.stringify({ error: 'Failed to fetch items' }), {
+      status: 500,
+      headers,
+    });
   }
 
-  return new Response(JSON.stringify({ data }), { headers });
+  return new Response(
+    JSON.stringify({
+      data: data ?? [],
+      pagination: {
+        total: count ?? 0,
+        page,
+        page_size: pageSize,
+      },
+    }),
+    { headers },
+  );
+};
+
+export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
+  const cors = initCors(request, env);
+  if ('response' in cors) {
+    return cors.response;
+  }
+
+  const { headers } = cors;
+  const supabase = createServiceRoleClient(env);
+
+  const authResult = await requireAuthUser(request, supabase, headers);
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { user } = authResult;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return new Response(JSON.stringify({ error: 'Invalid request body' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  const {
+    title,
+    description,
+    item_type_id: itemTypeId,
+    rarity_id: rarityId,
+    material_id: materialId,
+    stars,
+    image_url: imageUrl,
+  } = payload as Record<string, unknown>;
+
+  if (typeof title !== 'string' || !title.trim() || title.length > 200) {
+    return new Response(JSON.stringify({ error: 'title must be a non-empty string up to 200 characters' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (typeof description !== 'string' || !description.trim() || description.length > 2000) {
+    return new Response(JSON.stringify({ error: 'description must be a non-empty string up to 2000 characters' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (typeof itemTypeId !== 'number' || !Number.isInteger(itemTypeId) || itemTypeId <= 0) {
+    return new Response(JSON.stringify({ error: 'item_type_id must be a positive integer' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (typeof rarityId !== 'number' || !Number.isInteger(rarityId) || rarityId <= 0) {
+    return new Response(JSON.stringify({ error: 'rarity_id must be a positive integer' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (typeof materialId !== 'number' || !Number.isInteger(materialId) || materialId <= 0) {
+    return new Response(JSON.stringify({ error: 'material_id must be a positive integer' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  let starsValue = 0;
+  if (stars !== undefined) {
+    if (typeof stars !== 'number' || !Number.isInteger(stars) || stars < 0 || stars > 5) {
+      return new Response(JSON.stringify({ error: 'stars must be an integer between 0 and 5' }), {
+        status: 400,
+        headers,
+      });
+    }
+    starsValue = stars;
+  }
+
+  let normalizedImageUrl: string | null = null;
+  if (imageUrl !== undefined) {
+    if (imageUrl === null) {
+      normalizedImageUrl = null;
+    } else if (typeof imageUrl === 'string') {
+      const trimmed = imageUrl.trim();
+      try {
+        if (trimmed) {
+          const parsed = new URL(trimmed);
+          if (parsed.protocol !== 'https:') {
+            return new Response(JSON.stringify({ error: 'image_url must use https scheme' }), {
+              status: 400,
+              headers,
+            });
+          }
+          normalizedImageUrl = parsed.toString();
+        }
+      } catch (error) {
+        return new Response(JSON.stringify({ error: 'image_url must be a valid URL' }), {
+          status: 400,
+          headers,
+        });
+      }
+    } else {
+      return new Response(JSON.stringify({ error: 'image_url must be a string or null' }), {
+        status: 400,
+        headers,
+      });
+    }
+  }
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('items')
+    .insert({
+      title: title.trim(),
+      description: description.trim(),
+      item_type_id: itemTypeId,
+      rarity_id: rarityId,
+      material_id: materialId,
+      stars: starsValue,
+      owner_user_id: user.id,
+      image_url: normalizedImageUrl,
+    })
+    .select('id')
+    .single();
+
+  if (insertError || !inserted) {
+    return new Response(JSON.stringify({ error: 'Failed to create item' }), {
+      status: 500,
+      headers,
+    });
+  }
+
+  const { data: itemView, error: viewError } = await supabase
+    .from('items_public_v')
+    .select(
+      `
+        id,
+        title,
+        description,
+        item_type_id,
+        item_type_slug,
+        item_type_label,
+        rarity_id,
+        rarity_slug,
+        rarity_label,
+        rarity_color_hex,
+        material_id,
+        material_slug,
+        material_label,
+        stars,
+        created_at,
+        updated_at,
+        owner_user_id,
+        image_url
+      `,
+    )
+    .eq('id', inserted.id)
+    .maybeSingle();
+
+  if (viewError) {
+    return new Response(JSON.stringify({ error: 'Failed to load created item' }), {
+      status: 500,
+      headers,
+    });
+  }
+
+  return new Response(JSON.stringify({ data: itemView ?? { id: inserted.id } }), {
+    status: 201,
+    headers,
+  });
 };

--- a/functions/api/materials.ts
+++ b/functions/api/materials.ts
@@ -1,0 +1,30 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+import { createServiceRoleClient, handleOptions, initCors, type Env } from './_shared';
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request, env }) =>
+  handleOptions(request, env, ['GET']);
+
+export const onRequestGet: PagesFunction<Env> = async ({ env, request }) => {
+  const cors = initCors(request, env);
+  if ('response' in cors) {
+    return cors.response;
+  }
+
+  const { headers } = cors;
+  const supabase = createServiceRoleClient(env);
+
+  const { data, error } = await supabase
+    .from('materials')
+    .select('id, slug, label, sort')
+    .order('sort', { ascending: true })
+    .order('id', { ascending: true });
+
+  if (error) {
+    return new Response(JSON.stringify({ error: 'Failed to fetch materials' }), {
+      status: 500,
+      headers,
+    });
+  }
+
+  return new Response(JSON.stringify({ data: data ?? [] }), { headers });
+};

--- a/functions/api/me.ts
+++ b/functions/api/me.ts
@@ -1,0 +1,149 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+import {
+  createServiceRoleClient,
+  handleOptions,
+  initCors,
+  requireAuthUser,
+  type Env,
+} from './_shared';
+
+const USERNAME_MAX_LENGTH = 32;
+const USERNAME_MIN_LENGTH = 3;
+
+function normalizeUsername(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== 'string') {
+    throw new Error('username must be a string or null');
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('username cannot be empty');
+  }
+  if (trimmed.length < USERNAME_MIN_LENGTH || trimmed.length > USERNAME_MAX_LENGTH) {
+    throw new Error(`username must be between ${USERNAME_MIN_LENGTH} and ${USERNAME_MAX_LENGTH} characters`);
+  }
+  if (!/^[a-z0-9_\-]+$/i.test(trimmed)) {
+    throw new Error('username may only contain letters, numbers, underscores, or hyphens');
+  }
+  return trimmed;
+}
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request, env }) =>
+  handleOptions(request, env, ['GET', 'POST']);
+
+export const onRequestGet: PagesFunction<Env> = async ({ env, request }) => {
+  const cors = initCors(request, env);
+  if ('response' in cors) {
+    return cors.response;
+  }
+
+  const { headers } = cors;
+  const supabase = createServiceRoleClient(env);
+
+  const authResult = await requireAuthUser(request, supabase, headers);
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { user } = authResult;
+
+  const { data: profile, error } = await supabase
+    .from('user_profiles')
+    .select('user_id, username, created_at')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (error) {
+    return new Response(JSON.stringify({ error: 'Failed to load profile' }), {
+      status: 500,
+      headers,
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      data: {
+        id: user.id,
+        email: user.email,
+        username: profile?.username ?? null,
+        profile_created_at: profile?.created_at ?? null,
+        user_metadata: user.user_metadata ?? {},
+        app_metadata: user.app_metadata ?? {},
+        created_at: user.created_at,
+      },
+    }),
+    { headers },
+  );
+};
+
+export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
+  const cors = initCors(request, env);
+  if ('response' in cors) {
+    return cors.response;
+  }
+
+  const { headers } = cors;
+  const supabase = createServiceRoleClient(env);
+
+  const authResult = await requireAuthUser(request, supabase, headers);
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { user } = authResult;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return new Response(JSON.stringify({ error: 'Invalid request body' }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  let username: string | null = null;
+  try {
+    username = normalizeUsername((payload as Record<string, unknown>).username ?? null);
+  } catch (error) {
+    return new Response(JSON.stringify({ error: (error as Error).message }), {
+      status: 400,
+      headers,
+    });
+  }
+
+  const { data, error: upsertError } = await supabase
+    .from('user_profiles')
+    .upsert(
+      { user_id: user.id, username },
+      { onConflict: 'user_id', ignoreDuplicates: false },
+    )
+    .select('user_id, username')
+    .single();
+
+  if (upsertError || !data) {
+    return new Response(JSON.stringify({ error: 'Failed to update profile' }), {
+      status: 500,
+      headers,
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      data: {
+        user_id: data.user_id,
+        username: data.username,
+      },
+    }),
+    { status: 200, headers },
+  );
+};

--- a/functions/api/rarities.ts
+++ b/functions/api/rarities.ts
@@ -1,0 +1,30 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+import { createServiceRoleClient, handleOptions, initCors, type Env } from './_shared';
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request, env }) =>
+  handleOptions(request, env, ['GET']);
+
+export const onRequestGet: PagesFunction<Env> = async ({ env, request }) => {
+  const cors = initCors(request, env);
+  if ('response' in cors) {
+    return cors.response;
+  }
+
+  const { headers } = cors;
+  const supabase = createServiceRoleClient(env);
+
+  const { data, error } = await supabase
+    .from('rarities')
+    .select('id, slug, label, sort, color_hex')
+    .order('sort', { ascending: true })
+    .order('id', { ascending: true });
+
+  if (error) {
+    return new Response(JSON.stringify({ error: 'Failed to fetch rarities' }), {
+      status: 500,
+      headers,
+    });
+  }
+
+  return new Response(JSON.stringify({ data: data ?? [] }), { headers });
+};

--- a/functions/api/upload-url.ts
+++ b/functions/api/upload-url.ts
@@ -1,0 +1,99 @@
+import type { PagesFunction } from '@cloudflare/workers-types';
+import { createServiceRoleClient, handleOptions, initCors, requireAuthUser, type Env } from './_shared';
+
+const DEFAULT_EXTENSION = 'png';
+const MAX_EXTENSION_LENGTH = 10;
+
+export const onRequestOptions: PagesFunction<Env> = async ({ request, env }) =>
+  handleOptions(request, env, ['POST']);
+
+export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
+  const cors = initCors(request, env);
+  if ('response' in cors) {
+    return cors.response;
+  }
+
+  const { headers } = cors;
+  const supabase = createServiceRoleClient(env);
+
+  const authResult = await requireAuthUser(request, supabase, headers);
+  if ('response' in authResult) {
+    return authResult.response;
+  }
+
+  const { user } = authResult;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    payload = null;
+  }
+
+  let extension = DEFAULT_EXTENSION;
+  let contentType: string | undefined;
+
+  if (payload && typeof payload === 'object') {
+    const body = payload as Record<string, unknown>;
+    if (body.file_extension !== undefined) {
+      if (typeof body.file_extension !== 'string') {
+        return new Response(JSON.stringify({ error: 'file_extension must be a string' }), {
+          status: 400,
+          headers,
+        });
+      }
+      const sanitized = body.file_extension.trim().toLowerCase();
+      if (!sanitized || sanitized.length > MAX_EXTENSION_LENGTH || !/^[a-z0-9]+$/.test(sanitized)) {
+        return new Response(JSON.stringify({ error: 'file_extension must be alphanumeric (max 10 chars)' }), {
+          status: 400,
+          headers,
+        });
+      }
+      extension = sanitized;
+    }
+
+    if (body.content_type !== undefined) {
+      if (typeof body.content_type !== 'string') {
+        return new Response(JSON.stringify({ error: 'content_type must be a string' }), {
+          status: 400,
+          headers,
+        });
+      }
+      const trimmed = body.content_type.trim();
+      if (!trimmed || !/^[\w.-]+\/[\w.+-]+$/.test(trimmed)) {
+        return new Response(JSON.stringify({ error: 'content_type must be a valid MIME type' }), {
+          status: 400,
+          headers,
+        });
+      }
+      contentType = trimmed;
+    }
+  }
+
+  const objectKey = `${user.id}/${crypto.randomUUID()}.${extension}`;
+
+  const { data, error } = await supabase.storage
+    .from('item-images')
+    .createSignedUploadUrl(objectKey, {
+      contentType,
+      upsert: false,
+    });
+
+  if (error || !data) {
+    return new Response(JSON.stringify({ error: 'Failed to create upload URL' }), {
+      status: 500,
+      headers,
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      data: {
+        upload_url: data.signedUrl,
+        token: data.token,
+        object_key: objectKey,
+      },
+    }),
+    { status: 201, headers },
+  );
+};


### PR DESCRIPTION
## Summary
- add a shared Supabase helper with strict CORS handling for Cloudflare Pages functions
- implement item listing/creation along with taxonomy, upload URL, and profile endpoints backed by Supabase
- document the initial OP-Item-DB setup workflow in a numbered checklist

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e56c9890808324878f9343a1537a32